### PR TITLE
Add LMS plugin stub to allow seamless integration of the new skin.

### DIFF
--- a/UltralightSkin/HTML/ultralight/README.md
+++ b/UltralightSkin/HTML/ultralight/README.md
@@ -1,0 +1,1 @@
+This is where the resulting skin files belong.

--- a/UltralightSkin/Plugin.pm
+++ b/UltralightSkin/Plugin.pm
@@ -1,0 +1,32 @@
+package Plugins::UltralightSkin::Plugin;
+
+use File::Basename;
+use File::Spec::Functions qw(catfile catdir);
+
+use constant SKIN_DIR => 'HTML/ultralight';
+
+# this plugin registers the helper files (fonts, manifest) as raw downloads
+# this will allow Logitech Media Server to serve those files without a patch
+sub initPlugin {
+	my $baseDir = dirname($INC{'Plugins/UltralightSkin/Plugin.pm'});
+	my $skinDir = catdir($baseDir, SKIN_DIR);
+	
+	opendir(DIR, $skinDir) || do {
+		Slim::Utils::Log::logError('UltralightSkin: failed to read base folder with fonts');
+		return;
+	};
+
+	my @entries = readdir(DIR);
+
+	close(DIR);
+
+	for my $file (@entries) {
+		# extend the list of file extensions if needed
+		if ($file =~ /\.(?:eot|svg|woff2?|ttf|json)$/) {
+			$file = catfile($skinDir, $file);
+			Slim::Web::Pages->addRawDownload(basename($file), $file, Slim::Music::Info::typeFromSuffix($file));
+		}
+	}
+}
+
+1;

--- a/UltralightSkin/custom-types.conf
+++ b/UltralightSkin/custom-types.conf
@@ -1,0 +1,16 @@
+# content types supported by the Logitech Media Server
+# first column is unique three letter identifier or URL scheme
+# second column is file suffixes or URL 
+# third column are MIME content-types
+# fourth column is a Logitech Media Server file type
+# blank lines, non-three column lines and content after a # is ignored.
+
+#########################################################################
+#ID     Suffix          Mime Content-Type               Server File Type#
+#########################################################################
+json    json            application/x-javascript        -
+svg     svg             image/svg+xml                   -
+ttf     ttf             application/x-font-ttf          -
+woff    woff            application/font-woff           -
+woff2   woff2           application/font-woff2          -
+eot     eot             application/vnd.ms-fontobject   -

--- a/UltralightSkin/install.xml
+++ b/UltralightSkin/install.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<extension>
+	<id>d61ddfa2-f7ca-4fb0-a9be-1f242b4f6ec8</id>
+	<name>ULTRALIGHT_SKIN</name>
+	<module>Plugins::UltralightSkin::Plugin</module>
+	<version>0.1.0</version>
+	<description>PLUGIN_ULTRALIGHT_SKIN</description>
+	<creator>whomever</creator>
+	<defaultState>enabled</defaultState>
+	<type>2</type>
+	<enforce>1</enforce>
+	<targetApplication>
+		<id>Logitech Media Server</id>
+		<minVersion>7.9</minVersion>
+		<maxVersion>*</maxVersion>
+	</targetApplication>
+</extension>

--- a/UltralightSkin/strings.txt
+++ b/UltralightSkin/strings.txt
@@ -1,0 +1,5 @@
+ULTRALIGHT_SKIN
+	EN	Ultralight
+	
+PLUGIN_ULTRALIGHT_SKIN
+	EN	This is a light weight, responsive skin, suitable for mobile as well as desktop use.


### PR DESCRIPTION
The plugin would register the font files and the manifest file within LMS' web server. It additionally adds a custom-types.conf, registering the mime types.

In order for the skin to be picked up, the resulting index.html file etc. need to go to the HTML/ultralight sub-folder.